### PR TITLE
Add jpg/png to FileUpload allowedMimeTypes options

### DIFF
--- a/Configuration/Yaml/FormElements/Overrides/FileUpload.yaml
+++ b/Configuration/Yaml/FormElements/Overrides/FileUpload.yaml
@@ -4,6 +4,14 @@ prototypes:
       FileUpload:
         formEditor:
           editors:
+            300:
+              selectOptions:
+                80:
+                  value: image/jpeg
+                  label: formEditor.elements.FileUpload.editor.allowedMimeTypes.jpg
+                90:
+                  value: image/png
+                  label: formEditor.elements.FileUpload.editor.allowedMimeTypes.png
             310:
               identifier: multiple
               templateName: Inspector-CheckboxEditor

--- a/Resources/Private/Language/de.form.xlf
+++ b/Resources/Private/Language/de.form.xlf
@@ -22,6 +22,14 @@
                 <source>Enable multiple file upload</source>
                 <target>Aktiviere mehrfachen Datei-Upload</target>
             </trans-unit>
+            <trans-unit id="formEditor.elements.FileUpload.editor.allowedMimeTypes.jpg">
+                <source>Images (jpg)</source>
+                <target>Bilder (jpg)</target>
+            </trans-unit>
+            <trans-unit id="formEditor.elements.FileUpload.editor.allowedMimeTypes.png">
+                <source>Images (png)</source>
+                <target>Bilder (png)</target>
+            </trans-unit>
             <trans-unit id="formEditor.elements.Form.finisher.EmailToSender.editor.senderAddress.fieldExplanationText2">
                 <source>Set by site configuration and plugin</source>
                 <target>Wird durch die Site-Konfiguration und das Plugin gesetzt</target>

--- a/Resources/Private/Language/form.xlf
+++ b/Resources/Private/Language/form.xlf
@@ -19,6 +19,12 @@
             <trans-unit id="formEditor.elements.FileUpload.editor.enableMultiple.label">
                 <source>Enable multiple file upload</source>
             </trans-unit>
+            <trans-unit id="formEditor.elements.FileUpload.editor.allowedMimeTypes.jpg">
+                <source>Images (jpg)</source>
+            </trans-unit>
+            <trans-unit id="formEditor.elements.FileUpload.editor.allowedMimeTypes.png">
+                <source>Images (png)</source>
+            </trans-unit>
             <trans-unit id="formEditor.elements.BaseFormElementMixin.editor.label.tags">
                 <source>Tags</source>
             </trans-unit>


### PR DESCRIPTION
The core `FileUpload` editor's `allowedMimeTypes` multiselect only offers document types (doc, docx, xls, xlsx, pdf, odt, ods). Image mime types like `image/jpeg`/`image/png` can be set in the form YAML but aren't selectable in the form editor UI. This adds them as selectable options.